### PR TITLE
Guard SwiftUI code for non-Apple builds

### DIFF
--- a/Sources/WrkstrmKit/Displayable/CollectionViewDisplayable/HostingCollectionViewCell.swift
+++ b/Sources/WrkstrmKit/Displayable/CollectionViewDisplayable/HostingCollectionViewCell.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
   import SwiftUI
   import UIKit
 
@@ -51,4 +51,4 @@
       updateConstraintsIfNeeded()
     }
   }
-#endif  // canImport(UIKit)
+#endif

--- a/Sources/WrkstrmKit/Displayable/TableViewDisplayable/HostingTableViewCell.swift
+++ b/Sources/WrkstrmKit/Displayable/TableViewDisplayable/HostingTableViewCell.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
   import SwiftUI
   import UIKit
 
@@ -57,4 +57,4 @@
       updateConstraintsIfNeeded()
     }
   }
-#endif  // canImport(UIKit)
+#endif

--- a/Sources/WrkstrmSwiftUI/AnyTransition.swift
+++ b/Sources/WrkstrmSwiftUI/AnyTransition.swift
@@ -1,11 +1,13 @@
-import SwiftUI
+#if canImport(SwiftUI)
+  import SwiftUI
 
-extension AnyTransition {
-  public static var moveAndFade: AnyTransition {
-    let insertion = Self.move(edge: .trailing)
-      .combined(with: .opacity)
-    let removal = Self.scale
-      .combined(with: .opacity)
-    return .asymmetric(insertion: insertion, removal: removal)
+  extension AnyTransition {
+    public static var moveAndFade: AnyTransition {
+      let insertion = Self.move(edge: .trailing)
+        .combined(with: .opacity)
+      let removal = Self.scale
+        .combined(with: .opacity)
+      return .asymmetric(insertion: insertion, removal: removal)
+    }
   }
-}
+#endif

--- a/Sources/WrkstrmSwiftUI/IndexedRow.swift
+++ b/Sources/WrkstrmSwiftUI/IndexedRow.swift
@@ -1,16 +1,18 @@
-import SwiftUI
+#if canImport(SwiftUI)
+  import SwiftUI
 
-public final class IndexedRow<M>: Identifiable, ObservableObject {
-  public let id: Int
+  public final class IndexedRow<M>: Identifiable, ObservableObject {
+    public let id: Int
 
-  public let index: Int
+    public let index: Int
 
-  @Published public var element: M
+    @Published public var element: M
 
-  @_specialize(where M:_Trivial)
-  public init(id: Int, index: Int, element: M) {
-    self.id = id
-    self.index = index
-    self.element = element
+    @_specialize(where M:_Trivial)
+    public init(id: Int, index: Int, element: M) {
+      self.id = id
+      self.index = index
+      self.element = element
+    }
   }
-}
+#endif

--- a/Sources/WrkstrmSwiftUI/PreviewDevice.swift
+++ b/Sources/WrkstrmSwiftUI/PreviewDevice.swift
@@ -1,9 +1,11 @@
-import SwiftUI
+#if canImport(SwiftUI)
+  import SwiftUI
 
-extension PreviewDevice: @retroactive Equatable {}
+  extension PreviewDevice: @retroactive Equatable {}
 
-extension PreviewDevice: @retroactive Hashable {
-  public static let iPhoneSE: PreviewDevice = .init(rawValue: "iPhone SE")
+  extension PreviewDevice: @retroactive Hashable {
+    public static let iPhoneSE: PreviewDevice = .init(rawValue: "iPhone SE")
 
-  public static let iPhoneSXMax: PreviewDevice = .init(rawValue: "iPhone XS Max")
-}
+    public static let iPhoneSXMax: PreviewDevice = .init(rawValue: "iPhone XS Max")
+  }
+#endif

--- a/Sources/WrkstrmSwiftUI/UIImagePublisher.swift
+++ b/Sources/WrkstrmSwiftUI/UIImagePublisher.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
   import Combine
   import SwiftUI
   import UIKit

--- a/Sources/WrkstrmSwiftUIExp/ActivityViewController.swift
+++ b/Sources/WrkstrmSwiftUIExp/ActivityViewController.swift
@@ -1,6 +1,5 @@
-import SwiftUI
-
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
+  import SwiftUI
   import UIKit
   import WrkstrmCrossKit
 

--- a/Sources/WrkstrmSwiftUIExp/InterpolatingView.swift
+++ b/Sources/WrkstrmSwiftUIExp/InterpolatingView.swift
@@ -1,7 +1,7 @@
-import Foundation
-import SwiftUI
-
-#if canImport(UIKit)
+// swiftlint:disable file_length
+#if canImport(SwiftUI) && canImport(UIKit)
+  import Foundation
+  import SwiftUI
   import UIKit
 
   struct InterpolatingView: UIViewRepresentable {
@@ -88,4 +88,4 @@ import SwiftUI
       addMotionEffect(vertical)
     }
   }
-#endif  // canImport(UIKit)
+#endif

--- a/Sources/WrkstrmSwiftUIExp/PageControl.swift
+++ b/Sources/WrkstrmSwiftUIExp/PageControl.swift
@@ -1,6 +1,5 @@
-import SwiftUI
-
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
+  import SwiftUI
   import UIKit
 
   @available(iOS 13.0, *)

--- a/Sources/WrkstrmSwiftUIExp/PageViewController.swift
+++ b/Sources/WrkstrmSwiftUIExp/PageViewController.swift
@@ -1,6 +1,5 @@
-import SwiftUI
-
-#if canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit)
+  import SwiftUI
   import UIKit
 
   public struct PageViewController: UIViewControllerRepresentable {

--- a/Sources/WrkstrmSwiftUIExp/WebView.swift
+++ b/Sources/WrkstrmSwiftUIExp/WebView.swift
@@ -1,8 +1,8 @@
-import Combine
-import SwiftUI
-import WebKit
-
-#if canImport(UIKit)
+// swiftlint:disable file_length
+#if canImport(SwiftUI) && canImport(Combine) && canImport(WebKit) && canImport(UIKit)
+  import Combine
+  import SwiftUI
+  import WebKit
 
   // MARK: - WebView
 


### PR DESCRIPTION
## Summary
- conditionally compile SwiftUI-dependent helpers only when SwiftUI and related frameworks are available
- ensure UIKit hosting cells and experimental views are skipped on platforms lacking SwiftUI

## Testing
- `swift test` *(fails: value of optional type 'UnsafeMutablePointer<tm>?' must be unwrapped to a value of type 'UnsafeMutablePointer<tm>' in swift-log)*

------
https://chatgpt.com/codex/tasks/task_e_6896832b053083339ac96e290c7d1adf