### PR TITLE
refactor: migrate tests to Swift Testing

### DIFF
--- a/Tests/WrkstrmKitTests/WrksrmKitTests.swift
+++ b/Tests/WrkstrmKitTests/WrksrmKitTests.swift
@@ -1,14 +1,11 @@
-import XCTest
+import Testing
 
 @testable import WrkstrmKit
 
-final class WrkstrmKitTests: XCTestCase {
-  func testExample() {
-    // This is an example of a functional test case. Use XCTAssert and related functions to verify
-    // your tests produce the correct results.
-    let text = "Hello, World!"
-    XCTAssertEqual(text, "Hello, World!")
-  }
-
-  static var allTests = [("testExample", testExample)]
+@Test
+func testExample() {
+  // This is an example of a functional test case. Use #expect and related functions to verify
+  // your tests produce the correct results.
+  let text = "Hello, World!"
+  #expect(text == "Hello, World!")
 }

--- a/Tests/WrkstrmKitTests/XCTestManifests.swift
+++ b/Tests/WrkstrmKitTests/XCTestManifests.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    [testCase(WrkstrmKitTests.allTests)]
-  }
-#endif


### PR DESCRIPTION
## Summary
- migrate example test to Swift Testing framework
- remove obsolete XCTest manifest file

## Testing
- `swift test -q` *(fails: cannot find Apple-specific types like Screen and CGFloat)*

------
https://chatgpt.com/codex/tasks/task_e_689cead155f48333bad28d5a74f72eb1