### PR TITLE
Add SwiftTesting coverage for UIViewController throw message handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+- Use the Swift `Testing` library for new tests instead of XCTest.
+- Include comments explaining the intent of tests.

--- a/Tests/WrkstrmKitTests/UIViewControllerThrowTests.swift
+++ b/Tests/WrkstrmKitTests/UIViewControllerThrowTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import WrkstrmKit
+#if canImport(UIKit)
+import UIKit
+
+/// Verifies that `throw(message:)` produces a `String` error carrying the supplied message.
+@Test("throw(message:) surfaces the provided message")
+func throwMessageThrowsString() {
+  let controller = UIViewController()
+
+  // Attempt the throw to capture the error for assertion.
+  let error = #expect(throws: String.self) {
+    try controller.throw(message: "Test message") as UIViewController
+  }
+
+  // The thrown string should match the message we passed in.
+  #expect(error == "Test message")
+}
+#endif


### PR DESCRIPTION
## Summary
- switch `UIViewControllerThrowTests` to Swift Testing with comments
- document repository guideline to prefer Swift Testing over XCTest

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689e1d9529b483339ff6b196b5dd8bc7