### PR TITLE
Remove retroactive PreviewDevice conformances

### DIFF
--- a/Sources/WrkstrmSwiftUI/PreviewDevice.swift
+++ b/Sources/WrkstrmSwiftUI/PreviewDevice.swift
@@ -1,9 +1,7 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
-extension PreviewDevice: @retroactive Equatable {}
-
-extension PreviewDevice: @retroactive Hashable {
+extension PreviewDevice {
   public static let iPhoneSE: PreviewDevice = .init(rawValue: "iPhone SE")
 
   public static let iPhoneSXMax: PreviewDevice = .init(rawValue: "iPhone XS Max")


### PR DESCRIPTION
## Summary
- remove retroactive Equatable/Hashable conformances from PreviewDevice to avoid conflicts with modern Swift

## Testing
- `swift build`
- `swift test` *(fails: static property 'scaler' is not concurrency-safe)*

------
https://chatgpt.com/codex/tasks/task_e_68a6559b54dc8333ab69778bd079185e