### PR TITLE
Rename Grid to LayoutGrid for clarity

### DIFF
--- a/Sources/WrkstrmCrossKit/Displayable/LayoutGrid.swift
+++ b/Sources/WrkstrmCrossKit/Displayable/LayoutGrid.swift
@@ -1,7 +1,11 @@
 #if canImport(CoreGraphics)
 import CoreGraphics
 
-public struct Grid {
+/// A lightweight model describing a two-dimensional layout used to calculate
+/// item sizes for grid-based interfaces. This type is unrelated to SwiftUI's
+/// `Grid` view; it simply specifies the number of rows and columns available
+/// for placing content within a given frame.
+public struct LayoutGrid {
   public let rows: Int
 
   public let columns: Int

--- a/Sources/WrkstrmKit/StackViewController/StackViewController.swift
+++ b/Sources/WrkstrmKit/StackViewController/StackViewController.swift
@@ -31,7 +31,7 @@ extension StackViewController {
 
     case views([UIView], alignment: UIStackView.Alignment)
 
-    case grid(Grid)
+    case grid(LayoutGrid)
   }
 }
 


### PR DESCRIPTION
## Summary
- rename `Grid` to `LayoutGrid`
- add documentation explaining difference from SwiftUI's `Grid`
- update `StackViewController.Style` to reference `LayoutGrid`

## Testing
- `swift test` *(fails: static property 'scaler' is not concurrency-safe)*

------
https://chatgpt.com/codex/tasks/task_e_68a655b124bc8333938f7a489d3dbaed