### PR TITLE
Rename Animation to UIViewAnimation

### DIFF
--- a/Sources/WrkstrmKit/UIView/UIView+Animation.swift
+++ b/Sources/WrkstrmKit/UIView/UIView+Animation.swift
@@ -8,8 +8,8 @@ extension CGFloat {
 extension UIView {
   @discardableResult
   public func perform(
-    _ animation: Animation,
-    completion: Animation.Completion? = nil,
+    _ animation: UIViewAnimation,
+    completion: UIViewAnimation.Completion? = nil,
   ) -> UIViewPropertyAnimator {
     let options = animation.options
     let stage = animation.stage
@@ -22,7 +22,7 @@ extension UIView {
       self?.layoutIfNeeded()
     }
 
-    let finalCompletion: Animation.Completion = { [weak self] position in
+    let finalCompletion: UIViewAnimation.Completion = { [weak self] position in
       guard let self else { return }
       DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + options.hold) { [weak self] in
         guard let self else { return }

--- a/Sources/WrkstrmKit/UIView/UIView+Pulse.swift
+++ b/Sources/WrkstrmKit/UIView/UIView+Pulse.swift
@@ -14,7 +14,7 @@ extension UIView {
   public func pulseView(_ pulse: Bool, delay _: CGFloat) -> UIViewPropertyAnimator {
     guard pulse else {
       return perform(
-        .animation(
+        UIViewAnimation.animation(
           with: .options(duration: Self.pulseDuration, timingOptions: [.beginFromCurrentState]),
           .stage { [weak self] in self?.transform = .identity },
         ))
@@ -25,7 +25,7 @@ extension UIView {
       .allowUserInteraction,
       .beginFromCurrentState,
     ]
-    let start: Animation = .init(
+    let start: UIViewAnimation = .init(
       with: .options(duration: Self.pulseDuration, timingOptions: timingOptions),
       .stage { [weak self] in
         guard let self else { return }
@@ -36,7 +36,7 @@ extension UIView {
       },
     )
 
-    let next: Animation = .init(
+    let next: UIViewAnimation = .init(
       with: .options(duration: Self.pulseDuration, timingOptions: timingOptions),
       .stage { [weak self] in self?.transform = .identity },
       next: start,

--- a/Sources/WrkstrmKit/UIView/UIViewAnimation.swift
+++ b/Sources/WrkstrmKit/UIView/UIViewAnimation.swift
@@ -1,16 +1,16 @@
 #if canImport(UIKit)
 import UIKit
 
-public class Animation {
+public class UIViewAnimation {
   public typealias Completion = (UIViewAnimatingPosition) -> Void
 
   public let options: Options
 
   public let stage: Stage
 
-  public var next: Animation?
+  public var next: UIViewAnimation?
 
-  public init(with options: Options, _ stage: Stage, next: Animation?) {
+  public init(with options: Options, _ stage: Stage, next: UIViewAnimation?) {
     self.options = options
     self.stage = stage
     self.next = next
@@ -23,13 +23,13 @@ public class Animation {
   public static func animation(
     with options: Options,
     _ stage: Stage,
-    next _: Animation? = nil,
-  ) -> Animation {
+    next _: UIViewAnimation? = nil,
+  ) -> UIViewAnimation {
     .init(with: options, stage, next: nil)
   }
 }
 
-extension Animation {
+extension UIViewAnimation {
   public struct Options: Equatable {
     public let duration: TimeInterval
 
@@ -81,16 +81,16 @@ extension Animation {
   }
 }
 
-extension Animation: Sequence {
-  public func makeIterator() -> AnimationIterator {
-    AnimationIterator(animation: self)
+extension UIViewAnimation: Sequence {
+  public func makeIterator() -> UIViewAnimationIterator {
+    UIViewAnimationIterator(animation: self)
   }
 }
 
-public struct AnimationIterator: IteratorProtocol {
-  public var animation: Animation?
+public struct UIViewAnimationIterator: IteratorProtocol {
+  public var animation: UIViewAnimation?
 
-  public mutating func next() -> Animation? {
+  public mutating func next() -> UIViewAnimation? {
     guard let next = animation else {
       return nil
     }
@@ -98,4 +98,7 @@ public struct AnimationIterator: IteratorProtocol {
     return next
   }
 }
+
+@available(*, deprecated, renamed: "UIViewAnimation")
+public typealias Animation = UIViewAnimation
 #endif


### PR DESCRIPTION
## Summary
- Replace generic Animation class with UIViewAnimation
- Update UIKit helpers to reference UIViewAnimation
- Provide deprecated typealias Animation for backward compatibility

## Testing
- `swift test` (fails: static property 'scaler' is not concurrency-safe)


------
https://chatgpt.com/codex/tasks/task_e_68a6900ea934833386c9cea5883914ac