### PR TITLE
Rename View alias to PlatformView

### DIFF
--- a/Sources/WrkstrmCrossKit/View+Constraints.swift
+++ b/Sources/WrkstrmCrossKit/View+Constraints.swift
@@ -2,14 +2,14 @@
 #if canImport(UIKit)
 import UIKit
 
-public typealias View = UIView
+public typealias PlatformView = UIView
 #elseif os(OSX)
 import Cocoa
 
-public typealias View = NSView
+public typealias PlatformView = NSView
 #endif
 
-extension View {
+extension PlatformView {
   private enum AssociatedKey {
     @MainActor static var constraintCache = "wsm_constraintCache"
   }
@@ -121,7 +121,7 @@ extension View {
   /// - Parameter view: The view whose edges should be matched.
   /// - Precondition: `self` and `view` must share a common superview; otherwise Auto Layout will complain about unsatisfiable constraints or items not having a common ancestor.
   /// - Important: `translatesAutoresizingMaskIntoConstraints` is not modified and should be disabled prior to calling.
-  public func constrainEdges(to view: View) {
+  public func constrainEdges(to view: PlatformView) {
     constrainEqual(attribute: .top, to: view, .top)
     constrainEqual(attribute: .leading, to: view, .leading)
     constrainEqual(attribute: .trailing, to: view, .trailing)
@@ -134,7 +134,7 @@ extension View {
   /// - Precondition: Either `view` or `superview` must be non-`nil`; otherwise a `fatalError` is raised.
   /// - Note: Only alignment is affected; the view's size is unchanged.
   /// - Important: `translatesAutoresizingMaskIntoConstraints` is not modified.
-  public func constrainToCenter(in view: View? = nil) {
+  public func constrainToCenter(in view: PlatformView? = nil) {
     guard let container = view ?? superview else { fatalError() }
     centerXAnchor.constrainEqual(anchor: container.centerXAnchor)
     centerYAnchor.constrainEqual(anchor: container.centerYAnchor)

--- a/Tests/WrkstrmKitTests/ViewConstraintsTests.swift
+++ b/Tests/WrkstrmKitTests/ViewConstraintsTests.swift
@@ -3,10 +3,8 @@ import Testing
 @testable import WrkstrmCrossKit
 #if canImport(UIKit)
 import UIKit
-public typealias View = UIView
 #elseif os(macOS)
 import AppKit
-public typealias View = NSView
 #endif
 
 /// Expectation: `cache(_:)` stores a constraint's original constant so
@@ -14,7 +12,7 @@ public typealias View = NSView
 /// when constraints are adjusted for animations or state changes.
 @Test
 func testCacheAndResetRestoreConstant() {
-  let view = View()
+  let view = PlatformView()
   let constraint = view.widthAnchor.constraint(equalToConstant: 100)
   constraint.isActive = true
   view.cache(constraint)
@@ -28,8 +26,8 @@ func testCacheAndResetRestoreConstant() {
 /// size and position.
 @Test
 func testConstrainEdgesProducesExpectedConstraints() {
-  let container = View()
-  let child = View()
+  let container = PlatformView()
+  let child = PlatformView()
   child.translatesAutoresizingMaskIntoConstraints = false
   container.addSubview(child)
   child.constrainEdges(to: container)
@@ -48,8 +46,8 @@ func testConstrainEdgesProducesExpectedConstraints() {
 /// within a parent view.
 @Test
 func testConstrainToCenterProducesExpectedConstraints() {
-  let container = View()
-  let child = View()
+  let container = PlatformView()
+  let child = PlatformView()
   child.translatesAutoresizingMaskIntoConstraints = false
   container.addSubview(child)
   child.constrainToCenter(in: container)


### PR DESCRIPTION
## Summary
- rename cross-platform View alias to PlatformView
- update constraint helpers and tests to use PlatformView

## Testing
- `swift build`
- `swift test` *(fails: static property 'scaler' is not concurrency-safe)*

------
https://chatgpt.com/codex/tasks/task_e_68a68f3e23f883339b761e6ea850311e